### PR TITLE
Retain type of short_dumped dicts (etc?)

### DIFF
--- a/dumper/__init__.py
+++ b/dumper/__init__.py
@@ -630,11 +630,11 @@ def short_dump (val):
 
     else:
         try:
-            val = repr(val)
+            nval = repr(val)
         except UnicodeError as err:
-            val = "[got unicode error trying to represent value: " + str(err) +\
+            nval = "[got unicode error trying to represent value: " + str(err) +\
                 ']'
-        return object_summary (val) + ': ' + repr(val)
+        return object_summary (val) + ': ' + nval
     
         
 


### PR DESCRIPTION
Fixes ancient ancient issue where 'short_dump' reported small substructures as strings even when they weren't.

Looks like Dumper.py is extremely stable so I'm not sure if this pull request will go anywhere, but I wanted to offer it anyway! 

Thanks for creating Dumper.py! 